### PR TITLE
search for a rule number match as well

### DIFF
--- a/discord/cmd_rules_test.go
+++ b/discord/cmd_rules_test.go
@@ -88,7 +88,7 @@ func TestRulesSearch_Handle(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "abcd", dChan)
 	assert.Equal(t, &discordgo.MessageSend{
-		Content: "Too many hits. Rule details removed. Use @hud rule [RuleNumber] for more information.\nRule Number: G108\nTitle: Opponent's zone, no extension.\n------------------\nRule Number: G109\nTitle: Don't extend in multiple directions.\n------------------\nRule Number: G207\nTitle: Right of way.\n------------------\nRule Number: G208\nTitle: Don't climb on each other unless in the COMMUNITY.\n------------------\nRule Number: G403\nTitle: 1 GAME PIECE at a time (except in LOADING ZONE and COMMUNITY).\n------------------\nRule Number: G404\nTitle: Launching GAME PIECES is only okay in the COMMUNITY.\n------------------\nRule Number: H309\nTitle: Know your ROBOT setup.",
+		Content: "Too many hits. Rule details removed. Use @hud rules [RuleNumber] for more information.\nRule Number: G108\nTitle: Opponent's zone, no extension.\n------------------\nRule Number: G109\nTitle: Don't extend in multiple directions.\n------------------\nRule Number: G207\nTitle: Right of way.\n------------------\nRule Number: G208\nTitle: Don't climb on each other unless in the COMMUNITY.\n------------------\nRule Number: G403\nTitle: 1 GAME PIECE at a time (except in LOADING ZONE and COMMUNITY).\n------------------\nRule Number: G404\nTitle: Launching GAME PIECES is only okay in the COMMUNITY.\n------------------\nRule Number: H309\nTitle: Know your ROBOT setup.",
 	}, m)
 
 }


### PR DESCRIPTION
Allow users to use the `rules search` with a known rule number.

`@hud rules G301` already allows users to return details about a specific rule, but if users are used to just using the `@hud rules search [keyword]`, allow them to search for the rule number as well.

```
@hud rules g301

Rule Number: G301
Title: Be careful what you interact with.
Details: ROBOTS and OPERATOR CONSOLES are prohibited from the following actions with regards to interaction with ARENA elements. Items A-D exclude GAME PIECES. grabbing, A. grasping, B. attaching to (including the use of a vacuum or hook fastener to anchor to the FIELD carpet C. and excluding use of the DRIVER STATION hook-and-loop tape, plugging in to the provided power outlet, and plugging the provided Ethernet cable into the OPERATOR CONSOLE), D. deforming, E. becoming entangled with, F. suspending from, and G. damaging.
```

Other small tweaks:

* Added some more comments
* Fixed suggestion text `@hud rule` -> `@hud rules`